### PR TITLE
feature: removing spring security temporary until application shall call other applications

### DIFF
--- a/helm/shared-mobility-to-ref/values.yaml
+++ b/helm/shared-mobility-to-ref/values.yaml
@@ -21,10 +21,10 @@ common:
         path: "/actuator/health/livenessState"
       readiness:
         path: "/actuator/health/readinessState"
-  secrets:
-    auth:
-      - MNG_AUTH0_INT_CLIENT_ID
-      - MNG_AUTH0_INT_CLIENT_SECRET
+#  secrets:
+#    auth:
+#      - MNG_AUTH0_INT_CLIENT_ID
+#      - MNG_AUTH0_INT_CLIENT_SECRET
   configmap:
     enabled: true
     data:

--- a/src/main/kotlin/no/entur/shared/mobility/to/ref/Application.kt
+++ b/src/main/kotlin/no/entur/shared/mobility/to/ref/Application.kt
@@ -1,9 +1,13 @@
 package no.entur.shared.mobility.to.ref
 
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 import org.springframework.boot.runApplication
 
-@SpringBootApplication
+@SpringBootApplication(
+    exclude = [SecurityAutoConfiguration::class, ManagementWebSecurityAutoConfiguration::class],
+)
 class Application
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
Hei dere! 

Ref. det vi snakket om på standup i dag. Vi skrur av Spring Security på TO-REF foreløpig. Vi kan sette det opp på nytt igjen når denne applikasjonen skal begynne å kalle andre eller vi tar i bruk Kafka-køer. Dette er den enkleste måten å gjøre det på inntil videre. Når TO-REF skal kalle andre applikasjoner så skrur vi det på igjen og legger på Auth0 og Permission store. Med dette så kan vi nå begynne å teste litt mer. 